### PR TITLE
Sportkurseinschreibung & Sprachkursinfo korrigiert

### DIFF
--- a/tutorenleitfaden.tex
+++ b/tutorenleitfaden.tex
@@ -355,7 +355,6 @@ Eine Zusammenstellung von fürs Studium wichtigen Dokumenten und Links zu vielen
 \begin{itemize*}
 \item Bis zu 10 SWS kostenlose Sprachkurse beim Sprachenzentrum LSK für jeden Studenten
 \item Je nach Kurs gibt es Sprachzertifikate
-\item Für den Informatik-Master wird Englisch benötigt
 \item Webseite: http://lskonline.tu-dresden.de
 \end{itemize*}
 
@@ -444,8 +443,8 @@ Eine Zusammenstellung von fürs Studium wichtigen Dokumenten und Links zu vielen
 \subsection{Unisport}
 Das Universitätssportzentrum (USZ) bietet viele Sportarten an
 \begin{itemize*}
-\item Sportprogramm ab 28.10. auf der Homepage des USZ
-\item Einschreibung WS 16/17 am 11.10. Nachmittags, gestaffelt nach Sportarten
+\item Sportprogramm ab 28.09. auf der Homepage des USZ
+\item Einschreibung WS 16/17 am 10.10. Nachmittags, gestaffelt nach Sportarten
 \item Preise für Studenten recht günstig (zwischen ca. 25-50 Euro pro Semester)
 \item Bei begehrten Sportarten schnell sein. viele Kurse nach wenigen Minuten voll
 \end{itemize*}


### PR DESCRIPTION
Die Sportkurseinschreibung ist wahrscheinlich nicht mehr sonderlich relevant für dieses Jahr, aber der Vollständigkeit halber hab ichs mit korrigiert.
Für den Master Informatik sind keine Sprachkurse mehr Pflicht, es reicht auch wenn

> der Nachweis über die Englisch-Ausbildung auf Grundkurs-Niveau der gymnasialen Sekundarstufe erbracht wird

(siehe https://tu-dresden.de/ing/informatik/studium/studienangebot/master-studiengaenge/master-informatik/zugangsvoraussetzungen)